### PR TITLE
docs: update example

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ let read = {
  * @module password-prompt
  * @example
  * let prompt = require('password-prompt')
- * let password = prompt('password: ')
+ * let password = await prompt('password: ')
  * // password: ******
  * @param {string} [ask] - prompt output
  * @param {Object} [options]


### PR DESCRIPTION
The previous example seems to incorrectly imply that the return value is a string.
Change the snippet to use promise handling.